### PR TITLE
fix: Обновил datasource.url в конфигурации профилей ide, local-stack, для использование скимы mentor-service

### DIFF
--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -1,14 +1,12 @@
 server:
   port: 8085
 
-
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/it_mentor_community_platform
+    url: jdbc:postgresql://localhost:5432/it_mentor_community_platform?currentSchema=mentor_service
     username: root
     password: password
     driver-class-name: org.postgresql.Driver
-
 
 management:
   metrics:

--- a/src/main/resources/application-local-stack.yml
+++ b/src/main/resources/application-local-stack.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://database:5432/it_mentor_community_platform
+    url: jdbc:postgresql://database:5432/it_mentor_community_platform?currentSchema=mentor_service
     username: root
     password: password
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
Ручной тест через ide и через docker образ. Таблицы создаются в скиме mentor-service. Скима public пуста.
