### PR TITLE
feat: Продюсер нотификаций для менторов о сданных проектах

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/config/KafkaConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/config/KafkaConfig.java
@@ -4,14 +4,16 @@ import com.itmentorcommunityplatform.mentorservice.dto.event.ProjectCreatedEvent
 import com.itmentorcommunityplatform.mentorservice.dto.event.UserAuthenticatedEvent;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
-import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.kafka.support.converter.StringJsonMessageConverter;
@@ -19,6 +21,7 @@ import org.springframework.kafka.support.mapping.DefaultJackson2JavaTypeMapper;
 import org.springframework.kafka.support.mapping.Jackson2JavaTypeMapper;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +32,9 @@ import java.util.Map;
 public class KafkaConfig {
 
     private final KafkaProperties kafkaProperties;
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS;
 
     @Bean
     public RecordMessageConverter multiTypeConverter() {
@@ -42,6 +48,15 @@ public class KafkaConfig {
         typeMapper.setIdClassMapping(mappings);
         converter.setTypeMapper(typeMapper);
         return converter;
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory(){
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
     }
 
     @Bean
@@ -62,5 +77,10 @@ public class KafkaConfig {
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
         factory.setRecordMessageConverter(multiTypeConverter());
         return factory;
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate(){
+        return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/consumer/ProjectCreatedConsumer.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/consumer/ProjectCreatedConsumer.java
@@ -1,10 +1,17 @@
 package com.itmentorcommunityplatform.mentorservice.consumer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.itmentorcommunityplatform.mentorservice.dto.MentorDto;
+import com.itmentorcommunityplatform.mentorservice.dto.event.MentorNotificationEvent;
 import com.itmentorcommunityplatform.mentorservice.dto.event.ProjectCreatedEvent;
+import com.itmentorcommunityplatform.mentorservice.producer.MentorNotificationProducer;
+import com.itmentorcommunityplatform.mentorservice.service.MentorService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -12,10 +19,20 @@ import org.springframework.stereotype.Component;
 public class ProjectCreatedConsumer {
 
 
+    private final MentorService mentorService;
+    private final MentorNotificationProducer mentorNotificationProducer;
+
     @KafkaListener(topics = "${spring.kafka.topic.projects-project-created}", groupId = "mentor-service-cg")
-    public void consumerProjectCreatedEvent(ProjectCreatedEvent event) {
+    public void consumerProjectCreatedEvent(ProjectCreatedEvent event) throws JsonProcessingException {
         log.info("Kafka Consumer: Received user's project create event: {}", event);
         try {
+            List<MentorDto> mentors = mentorService.searchMentorsByLanguageAndProjectType(event.getProgrammingLanguage(), event.getRoadmapProject());
+            mentorNotificationProducer.notificateMentors(
+                    MentorNotificationEvent.builder()
+                            .project(event)
+                            .mentors(mentors)
+                            .build()
+            );
             log.info("Kafka Consumer: Successfully processed event for user's project {}", event.getGithubRepositoryUrl());
         } catch (Exception e) {
             log.error("Kafka Consumer: Error processing event for user's project {}", event.getGithubRepositoryUrl(), e);

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/consumer/ProjectCreatedConsumer.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/consumer/ProjectCreatedConsumer.java
@@ -1,6 +1,5 @@
 package com.itmentorcommunityplatform.mentorservice.consumer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.itmentorcommunityplatform.mentorservice.dto.MentorDto;
 import com.itmentorcommunityplatform.mentorservice.dto.event.MentorNotificationEvent;
 import com.itmentorcommunityplatform.mentorservice.dto.event.ProjectCreatedEvent;
@@ -23,15 +22,12 @@ public class ProjectCreatedConsumer {
     private final MentorNotificationProducer mentorNotificationProducer;
 
     @KafkaListener(topics = "${spring.kafka.topic.projects-project-created}", groupId = "mentor-service-cg")
-    public void consumerProjectCreatedEvent(ProjectCreatedEvent event) throws JsonProcessingException {
+    public void consumerProjectCreatedEvent(ProjectCreatedEvent event) {
         log.info("Kafka Consumer: Received user's project create event: {}", event);
         try {
             List<MentorDto> mentors = mentorService.searchMentorsByLanguageAndProjectType(event.getProgrammingLanguage(), event.getRoadmapProject());
             mentorNotificationProducer.notificateMentors(
-                    MentorNotificationEvent.builder()
-                            .project(event)
-                            .mentors(mentors)
-                            .build()
+                    new MentorNotificationEvent(event, mentors)
             );
             log.info("Kafka Consumer: Successfully processed event for user's project {}", event.getGithubRepositoryUrl());
         } catch (Exception e) {

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/dto/MentorDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/dto/MentorDto.java
@@ -1,0 +1,11 @@
+package com.itmentorcommunityplatform.mentorservice.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public record MentorDto(
+        Long mentorTelegramUserId,
+        String mentorTelegramProfileUrl
+) {
+}

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/dto/MentorDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/dto/MentorDto.java
@@ -1,9 +1,6 @@
 package com.itmentorcommunityplatform.mentorservice.dto;
 
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public record MentorDto(
         Long mentorTelegramUserId,
         String mentorTelegramProfileUrl

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/dto/event/MentorNotificationEvent.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/dto/event/MentorNotificationEvent.java
@@ -1,0 +1,23 @@
+package com.itmentorcommunityplatform.mentorservice.dto.event;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.itmentorcommunityplatform.mentorservice.dto.MentorDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class MentorNotificationEvent {
+
+    ProjectCreatedEvent project;
+    List<MentorDto> mentors;
+
+}

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/mapper/MentorMapper.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/mapper/MentorMapper.java
@@ -1,0 +1,22 @@
+package com.itmentorcommunityplatform.mentorservice.mapper;
+
+import com.itmentorcommunityplatform.mentorservice.domain.Mentor;
+import com.itmentorcommunityplatform.mentorservice.dto.MentorDto;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MentorMapper {
+
+    public List<MentorDto> toMentorDtoList(List<Mentor> mentors){
+        List<MentorDto> result = new ArrayList<>();
+        for (Mentor mentor : mentors){
+            MentorDto mentorDto = new MentorDto(mentor.getMentorTelegramUserId(), mentor.getTelegramUrl());
+            result.add(mentorDto);
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/producer/MentorNotificationProducer.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/producer/MentorNotificationProducer.java
@@ -1,0 +1,37 @@
+package com.itmentorcommunityplatform.mentorservice.producer;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itmentorcommunityplatform.mentorservice.dto.event.MentorNotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MentorNotificationProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${spring.kafka.topic.notification-mentors-project-submitted}")
+    private String mentorsNotificationTopic;
+
+
+    public void notificateMentors(MentorNotificationEvent event) throws JsonProcessingException {
+        log.info("Kafka Producer: Starting mentor notification event: {}", event);
+        try {
+            String message = objectMapper.writeValueAsString(event);
+            kafkaTemplate.send(mentorsNotificationTopic, message);
+            log.info("Kafka Consumer: Successfully processed notification event for mentors {}", event.getMentors());
+        } catch (Exception e) {
+            log.error("Kafka Producer: Error processing notification for mentors {}", event.getMentors(), e);
+            throw e;
+        }
+    }
+
+}

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/producer/MentorNotificationProducer.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/producer/MentorNotificationProducer.java
@@ -1,14 +1,12 @@
 package com.itmentorcommunityplatform.mentorservice.producer;
 
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itmentorcommunityplatform.mentorservice.dto.event.MentorNotificationEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.beans.factory.annotation.Value;
 
 @Service
 @RequiredArgsConstructor
@@ -16,18 +14,16 @@ import org.springframework.beans.factory.annotation.Value;
 public class MentorNotificationProducer {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
-    private final ObjectMapper objectMapper;
 
     @Value("${spring.kafka.topic.notification-mentors-project-submitted}")
     private String mentorsNotificationTopic;
 
 
-    public void notificateMentors(MentorNotificationEvent event) throws JsonProcessingException {
+    public void notificateMentors(MentorNotificationEvent event) {
         log.info("Kafka Producer: Starting mentor notification event: {}", event);
         try {
-            String message = objectMapper.writeValueAsString(event);
-            kafkaTemplate.send(mentorsNotificationTopic, message);
-            log.info("Kafka Consumer: Successfully processed notification event for mentors {}", event.getMentors());
+            kafkaTemplate.send(mentorsNotificationTopic, event);
+            log.info("Kafka Producer: Successfully processed notification event for mentors {}", event.getMentors());
         } catch (Exception e) {
             log.error("Kafka Producer: Error processing notification for mentors {}", event.getMentors(), e);
             throw e;

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/repository/MentorsRepository.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/repository/MentorsRepository.java
@@ -52,6 +52,6 @@ public interface MentorsRepository extends CrudRepository<Mentor, Long> {
             LEFT JOIN guaranteed_reviews_prices grp ON m.id = grp.mentor_id
             WHERE grp.project_type = :projectType AND grp.language = :language
             """)
-    List<Mentor> getMentorsListByProgramingLanguages(@Param("language") String language,
+    List<Mentor> findAllMentorsByProgrammingLanguageAndProjectType(@Param("language") String language,
                                                                 @Param("projectType") String projectType);
 }

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/repository/MentorsRepository.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/repository/MentorsRepository.java
@@ -1,9 +1,7 @@
 package com.itmentorcommunityplatform.mentorservice.repository;
 
 import com.itmentorcommunityplatform.mentorservice.domain.Mentor;
-import com.itmentorcommunityplatform.mentorservice.domain.MentorDescription;
 import com.itmentorcommunityplatform.mentorservice.dto.MentorUpsertResult;
-import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -49,4 +47,11 @@ public interface MentorsRepository extends CrudRepository<Mentor, Long> {
 
     Optional<Mentor> getMentorByMentorTelegramUserId(Long mentorTelegramUserId);
 
+    @Query("""
+            SELECT * FROM mentors m
+            LEFT JOIN guaranteed_reviews_prices grp ON m.id = grp.mentor_id
+            WHERE grp.project_type = :projectType AND grp.language = :language
+            """)
+    List<Mentor> getMentorsListByProgramingLanguages(@Param("language") String language,
+                                                                @Param("projectType") String projectType);
 }

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/service/MentorService.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/service/MentorService.java
@@ -57,9 +57,8 @@ public class MentorService {
         return inserted ? UpsertResult.CREATED : UpsertResult.UPDATED;
     }
 
-    @Transactional
     public List<MentorDto> searchMentorsByLanguageAndProjectType(String language, String projectType){
-        return mentorMapper.toMentorDtoList(mentorsRepository.getMentorsListByProgramingLanguages(language, projectType));
+        return mentorMapper.toMentorDtoList(mentorsRepository.findAllMentorsByProgrammingLanguageAndProjectType(language, projectType));
     }
 
     @Transactional

--- a/src/main/java/com/itmentorcommunityplatform/mentorservice/service/MentorService.java
+++ b/src/main/java/com/itmentorcommunityplatform/mentorservice/service/MentorService.java
@@ -3,13 +3,11 @@ package com.itmentorcommunityplatform.mentorservice.service;
 import com.itmentorcommunityplatform.mentorservice.domain.Mentor;
 import com.itmentorcommunityplatform.mentorservice.domain.MentorDescription;
 import com.itmentorcommunityplatform.mentorservice.domain.MentorProgrammingLanguage;
+import com.itmentorcommunityplatform.mentorservice.dto.*;
 import com.itmentorcommunityplatform.mentorservice.domain.type.UpsertResult;
-import com.itmentorcommunityplatform.mentorservice.dto.AddMentorWithDescriptionRequest;
-import com.itmentorcommunityplatform.mentorservice.dto.AddPriceForGuaranteedReviewRequest;
-import com.itmentorcommunityplatform.mentorservice.dto.MentorUpsertResult;
-import com.itmentorcommunityplatform.mentorservice.dto.ProfileWithTelegramIdDto;
 import com.itmentorcommunityplatform.mentorservice.dto.event.UserAuthenticatedEvent;
 import com.itmentorcommunityplatform.mentorservice.httpclient.ServiceHttpClient;
+import com.itmentorcommunityplatform.mentorservice.mapper.MentorMapper;
 import com.itmentorcommunityplatform.mentorservice.repository.MentorsRepository;
 import com.itmentorcommunityplatform.mentorservice.repository.ProgrammingLanguagesRepository;
 import com.itmentorcommunityplatform.mentorservice.repository.ServicesRepository;
@@ -39,6 +37,7 @@ public class MentorService {
     private final ProgrammingLanguagesRepository programmingLanguagesRepository;
     private final ServicesRepository servicesRepository;
     private final ServiceHttpClient httpClient;
+    private final MentorMapper mentorMapper;
 
     @Transactional
     public UpsertResult upsertMentorAndGuaranteedReviewsPrices(AddPriceForGuaranteedReviewRequest request) {
@@ -56,6 +55,11 @@ public class MentorService {
                 request.language());
 
         return inserted ? UpsertResult.CREATED : UpsertResult.UPDATED;
+    }
+
+    @Transactional
+    public List<MentorDto> searchMentorsByLanguageAndProjectType(String language, String projectType){
+        return mentorMapper.toMentorDtoList(mentorsRepository.getMentorsListByProgramingLanguages(language, projectType));
     }
 
     @Transactional

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -13,7 +13,9 @@ spring:
     topic:
       auth-user-authenticated: auth.user.authenticated
       projects-project-created: projects.project.created
-
+      notification-mentors-project-submitted: notifications.mentors.project.submitted
+  jpa:
+    show-sql: true
 management:
   metrics:
     tags:

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -14,8 +14,6 @@ spring:
       auth-user-authenticated: auth.user.authenticated
       projects-project-created: projects.project.created
       notification-mentors-project-submitted: notifications.mentors.project.submitted
-  jpa:
-    show-sql: true
 management:
   metrics:
     tags:

--- a/src/main/resources/application-local-stack.yml
+++ b/src/main/resources/application-local-stack.yml
@@ -10,6 +10,7 @@ spring:
     topic:
       auth-user-authenticated: auth.user.authenticated
       projects-project-created: projects.project.created
+      notification-mentors-project-submitted: notifications.mentors.project.submitted
 
 mentorservice:
   profile-service-base-url: "http://profile-service:8080"

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -8,6 +8,7 @@ spring:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     topic:
       auth-user-authenticated: staging.auth.user.authenticated
+      notification-mentors-project-submitted: staging.notifications.mentors.project.submitted
     properties:
       security.protocol: ${KAFKA_SECURITY_PROTOCOL}
       sasl.mechanism: ${KAFKA_SASL_MECHANISM}


### PR DESCRIPTION
- Реализовать выбор релевантных менторов (по языку программирования и типу проекта из роадмапа) к проектам полученным из топика projects.project.created

- Создать продюсер для нового топика notifications.mentors.project.submitted.

- Доделал консьюмер projects.project.created, добавив отправку события в продюсер 